### PR TITLE
Grammar and spelling adjustments across project files

### DIFF
--- a/3rdparty/popl/README.md
+++ b/3rdparty/popl/README.md
@@ -88,7 +88,7 @@ Options have an `Attribute`: they can be hidden in the auto-created help message
 ```C++
 auto string_option = op.add<Value<std::string>>("s", "string", "some string value");
 auto advanced_int  = op.add<Value<int>, Attribute::advanced>("i", "integer", "advanced integer value");
-auto hidden_bool   = op.add<Swtich, Attribute::hidden>("", "hidden", "hidden flag");
+auto hidden_bool   = op.add<Switch, Attribute::hidden>("", "hidden", "hidden flag");
 ```
 
 Now `cout << op.help()` (same as `cout << op`) will not show the hidden or advanced option, while `cout << op.help(Visibility::advanced)` will show the advanced option. The hidden one is never shown to the user.  

--- a/examples/Blink-Daemon/README.md
+++ b/examples/Blink-Daemon/README.md
@@ -10,7 +10,7 @@ We start by building the Blinkd project with Codelite, we will take care to
 choose the Release configuration.
 
 Once the compilation is done, copy the program to `/usr/local/bin` and the 
-ervice script in `/etc/init.d` :
+service script in `/etc/init.d` :
 
     $ sudo install -m0755 Release/Blinkd /usr/local/bin
     $ sudo install -m0755 blinkd /etc/init.d

--- a/examples/Spi/SpiMemoryMb85rs/mb85rs.cpp
+++ b/examples/Spi/SpiMemoryMb85rs/mb85rs.cpp
@@ -21,7 +21,7 @@ Mb85rs::Mb85rs (int csPin, size_t size) : _cspin (csPin), _size (size),
 void Mb85rs::begin (uint32_t fclk) {
 
   _settings.speedHz = fclk;
-  // initalize the chip select pin
+  // initialize the chip select pin
   pinMode (_cspin, OUTPUT);
   digitalWrite (_cspin, HIGH);
 }

--- a/examples/Spi/SpiPressureSensorHsc/main.cpp
+++ b/examples/Spi/SpiPressureSensorHsc/main.cpp
@@ -52,7 +52,7 @@ void setup() {
   // start the SPI library:
   SPI.begin();
 
-  // initalize the chip select pin
+  // initialize the chip select pin
   pinMode (chipSelectPin, OUTPUT);
   digitalWrite (chipSelectPin, HIGH);
 }

--- a/src/arch/arm/broadcom/gpio_rp1.cpp
+++ b/src/arch/arm/broadcom/gpio_rp1.cpp
@@ -86,7 +86,7 @@ namespace Piduino {
         d->flags &= ~useGpioMem; // clear the flag to use /dev/gpiomem
       }
       d->pad = &d->gpio[PadsOffset]; // RP1 start address of map memory for pad
-      d->rio  = &d->gpio[RioOffset]; // RP1 start adress of map memory for rio
+      d->rio  = &d->gpio[RioOffset]; // RP1 start address of map memory for rio
       d->isopen = true;
     }
     return isOpen();

--- a/src/arch/arm/broadcom/gpio_rp1.cpp
+++ b/src/arch/arm/broadcom/gpio_rp1.cpp
@@ -85,7 +85,7 @@ namespace Piduino {
         d->gpio = d->iomap[GpioOffset]; // pointer to the GPIO registers
         d->flags &= ~useGpioMem; // clear the flag to use /dev/gpiomem
       }
-      d->pad = &d->gpio[PadsOffset]; // RP1 start adress of map memory for pad
+      d->pad = &d->gpio[PadsOffset]; // RP1 start address of map memory for pad
       d->rio  = &d->gpio[RioOffset]; // RP1 start adress of map memory for rio
       d->isopen = true;
     }

--- a/src/gpio/gpiopin-database.cpp
+++ b/src/gpio/gpiopin-database.cpp
@@ -79,7 +79,7 @@ namespace Piduino {
 
     for (auto it = name.begin(); it != name.end(); ++it) {
 
-      // Recherche tous les pin_id correspondants au nom et au mode courant
+      // Recherche tous les pin_id correspondents au nom et au mode courant
       res = Piduino::db <<
             "SELECT pin_has_name.pin_id "
             " FROM pin_has_name "

--- a/src/gpio/gpiopin.cpp
+++ b/src/gpio/gpiopin.cpp
@@ -840,5 +840,5 @@ namespace Piduino {
     return os;
   }
 
-} // namesapce Piduino
+} // namespace Piduino
 /* ========================================================================== */

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -46,7 +46,7 @@ namespace Piduino {
   String::toString (unsigned long num, unsigned char base) {
     String str;
 
-    /* Handle 0 explicitely, otherwise empty string is printed for 0 */
+    /* Handle 0 explicitly, otherwise empty string is printed for 0 */
     if (num == 0) {
 
       str.push_back ('0');

--- a/tests/benchmarks/bench1-pin/main.cpp
+++ b/tests/benchmarks/bench1-pin/main.cpp
@@ -1,5 +1,5 @@
 // GPIO Pin benchmark
-// This programm changes the state of a GPIO pin 100 times as fast as possible to measure
+// This program changes the state of a GPIO pin 100 times as fast as possible to measure
 // the processing time that can be measured with an oscilloscope.
 // Generates a frame of 100 pulses then waits 10 ms before repeating.
 // This program is used to benchmark the GPIO performance.

--- a/tests/test1-gpio2/main.cpp
+++ b/tests/test1-gpio2/main.cpp
@@ -434,7 +434,7 @@ TEST_FIXTURE (LineIn12Fixture, Test4) {
 
   begin (4, "Multiple Line tests");
 
-  // Chech getters
+  // Check getters
   CHECK (line.isOpen() == false);
   for (unsigned int i = 0; i < line.numLines(); ++i) {
     CHECK (line.offset (i) == offsets[i]);


### PR DESCRIPTION
Performed a language cleanup pass over documentation and comments.

### Modified elements:
- `3rdparty/popl/README.md`, line 91: `Swtich` → `Switch`
- `examples/Blink-Daemon/README.md`, line 13: `ervice` → `service`
- `examples/Spi/SpiMemoryMb85rs/mb85rs.cpp`, line 24: `initalize` → `initialize`
- `examples/Spi/SpiPressureSensorHsc/main.cpp`, line 55: `initalize` → `initialize`
- `src/arch/arm/broadcom/gpio_rp1.cpp`, line 88: `adress` → `address`
- `src/arch/arm/broadcom/gpio_rp1.cpp`, line 89: `adress` → `address`
- `src/gpio/gpiopin-database.cpp`, line 82: `correspondants` → `correspondents`
- `src/gpio/gpiopin.cpp`, line 843: `namesapce` → `namespace`
- `src/string.cpp`, line 49: `explicitely` → `explicitly`
- `tests/benchmarks/bench1-pin/main.cpp`, line 2: `programm` → `program`
- `tests/test1-gpio2/main.cpp`, line 437: `Chech` → `Check`

No source logic or behavior has been modified.